### PR TITLE
build: add wheel package config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,3 +17,6 @@ dependencies = [
 
 [project.scripts]
 digest = "beancount_utils.digest:main"
+
+[tool.hatch.build.targets.wheel]
+packages = ["beancount_utils"]


### PR DESCRIPTION
This resolves an error when installing from pip+git:

    ValueError: Unable to determine which files to ship inside the wheel
    using the following heuristics:
    https://hatch.pypa.io/latest/plugins/builder/wheel/#default-file-selection

      The most likely cause of this is that there is no directory that
      matches the name of your project (beancount_utils).

      At least one file selection option must be defined in the
      `tool.hatch.build.targets.wheel` table, see:
      https://hatch.pypa.io/latest/config/build/

      As an example, if you intend to ship a directory named `foo` that
      resides within a `src` directory located at the root of your
      project, you can define the following:

      [tool.hatch.build.targets.wheel]
      packages = ["src/foo"]
      [end of output]
